### PR TITLE
Remove premature optimization

### DIFF
--- a/components/TodoItem.js
+++ b/components/TodoItem.js
@@ -28,8 +28,7 @@ class TodoItem extends Component {
   render() {
     const {
       todo,
-      isCompleted,
-      isRelatedTodoCompleted,
+      relatedTodo,
       completeTodo,
       deleteTodo,
     } = this.props
@@ -49,10 +48,10 @@ class TodoItem extends Component {
           <input
             className="toggle"
             type="checkbox"
-            checked={isCompleted}
+            checked={todo.isCompleted}
             onChange={() => completeTodo(todo.id)} />
           <label onDoubleClick={this.handleDoubleClick.bind(this)}>
-            {todo.text} {isRelatedTodoCompleted ? "(+)" : "(-)"}
+            {todo.text} {relatedTodo && relatedTodo.isCompleted ? "(+)" : "(-)"}
           </label>
           <button
             className="destroy"
@@ -63,7 +62,7 @@ class TodoItem extends Component {
 
     return (
       <li className={classnames({
-        completed: isCompleted,
+        completed: todo.isCompleted,
         editing: this.state.editing
       })}>
         {element}
@@ -85,10 +84,10 @@ const makeMapStateToProps = (initialState, initialProps) => {
   const mapStateToProps = (state) => {
     const { todos } = state
     const todo = todos.byId[id]
+    const relatedTodo = todo.relatedId && todos.byId[todo.relatedId]
     return {
       todo,
-      isCompleted: todos.isCompletedById[id],
-      isRelatedTodoCompleted: todos.isCompletedById[todo.relatedId]
+      relatedTodo
     }
   }
   return mapStateToProps

--- a/reducers/index.js
+++ b/reducers/index.js
@@ -12,17 +12,17 @@ export default combineReducers({
 export const getVisibleTodoIds = createSelector(
   [
     state => state.todos.listedIds,
-    state => state.todos.isCompletedById,
+    state => state.todos.byId,
     state => state.filter,
   ],
-  (listedIds, isCompletedById, filter) => {
+  (listedIds, byId, filter) => {
     switch (filter) {
       case SHOW_ALL:
         return listedIds
       case SHOW_COMPLETED:
-        return listedIds.filter(id => isCompletedById[id])
+        return listedIds.filter(id => byId[id].isCompleted)
       case SHOW_ACTIVE:
-        return listedIds.filter(id => !isCompletedById[id])
+        return listedIds.filter(id => !byId[id].isCompleted)
     }
   }
 )
@@ -35,8 +35,8 @@ export const getListedCount = createSelector(
 export const getCompletedCount = createSelector(
   [
     state => state.todos.listedIds,
-    state => state.todos.isCompletedById
+    state => state.todos.byId
   ],
-  (listedIds, isCompletedById) =>
-    listedIds.filter(id => isCompletedById[id]).length
+  (listedIds, byId) =>
+    listedIds.filter(id => byId[id].isCompleted).length
 )


### PR DESCRIPTION
So, keeping `isCompletedById` gave a slight (10ms on 10K list) benefit in the benchmark but it turns out it was optimizing for the case when little todos are toggled. If we toggle all todos and then toggle one, there is no perf benefit to separating `isCompletedById`.

Redux loses a few points but gains some readability, and the solution looks more idiomatic and less prone to fluctuating conditions.
